### PR TITLE
Add initial mock server for testing

### DIFF
--- a/rpc.go
+++ b/rpc.go
@@ -13,6 +13,19 @@ import (
 	"github.com/rddl-network/elements-rpc/types"
 )
 
+// HTTPClient interface
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+var (
+	Client HTTPClient
+)
+
+func init() {
+	Client = &http.Client{}
+}
+
 func parse(params []string) (param string, err error) {
 	if len(params) == 0 {
 		err = errors.New("parameters must not be empty")
@@ -40,8 +53,7 @@ func SendRequest(url, method string, params []string) (result []byte, err error)
 	}
 	request.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{}
-	resp, err := client.Do(request)
+	resp, err := Client.Do(request)
 	if err != nil {
 		return
 	}

--- a/utils/mocks/client.go
+++ b/utils/mocks/client.go
@@ -1,0 +1,65 @@
+package mocks
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/rddl-network/elements-rpc/types"
+)
+
+// Body mocks the request sent to the elements' RPC
+type Body struct {
+	Jsonrpc string `json:"jsonrpc"`
+	Method  string `json:"method"`
+	Params  []any  `json:"params"`
+}
+
+// MockClient is the mock client
+type MockClient struct {
+	DoFunc func(req *http.Request) (*http.Response, error)
+}
+
+var (
+	txID = "0000000000000000000000000000000000000000000000000000000000000000"
+)
+
+// GetDoFunc fetches the mock client's `Do` func
+func GetDoFunc(req *http.Request) (*http.Response, error) {
+	var body Body
+	bodyBytes, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(bodyBytes, &body)
+	if err != nil {
+		return nil, err
+	}
+	var response types.Response
+	switch body.Method {
+	case "reissueasset":
+		reissueAssetResult := types.ReissueAssetResult{TxID: txID, Vin: 0}
+		response.Result = reissueAssetResult
+		response.Error.Code = 0
+		response.Error.Message = ""
+	default:
+		response.Result = nil
+		response.Error.Code = -1337
+		response.Error.Message = "method not implemented"
+	}
+	respBytes, err := json.Marshal(&response)
+	if err != nil {
+		return nil, err
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader(respBytes)),
+	}
+	return resp, nil
+}
+
+// Do is the mock client's `Do` func
+func (m *MockClient) Do(req *http.Request) (*http.Response, error) {
+	return GetDoFunc(req)
+}


### PR DESCRIPTION
- Introduces a new public `Client` variable
- It implements the `HTTPClient` interface
- The `mock` package overrides these
- Method `reissueasset` is mocked

// See https://www.thegreatcodeadventure.com/mocking-http-requests-in-golang/