### PR TITLE
Removed special handling of 1st rpc cmd argument

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,10 @@ jobs:
         run: |
           go build -v ./...
 
+      - name: Go test
+        run: |
+          go test -v ./...
+
       - name: Release
         uses: softprops/action-gh-release@v1
         with:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ func main() {
         url := "http://user:password@127.0.0.1:18891/wallet/foowallet"
         assetID := "7add40beb27df701e02ee85089c5bc0021bc813823fedb5f1dcb5debda7f3da9"
 
-        result, err := elements.ReissueAsset(url, []string{assetID, "100.00000000"})
+        result, err := elements.ReissueAsset(url, []string{
+                `"` + assetID + `"`,
+                "100.00000000",
+        })
         if err != nil {
                 log.Fatal(err)
         }
@@ -48,7 +51,7 @@ func main() {
         assetID := "7add40beb27df701e02ee85089c5bc0021bc813823fedb5f1dcb5debda7f3da9"
 
         hex, err := elements.SendToAddress(url, []string{
-                "tlq1qqg4eudh5kes0pw903stdzvzdwrgrtg6nvqynvz9p9pler7xeugaau9s5h0plnqwchl5cgj2el03y5e0m65usqyyawjg9dar6t",
+                `"tlq1qqg4eudh5kes0pw903stdzvzdwrgrtg6nvqynvz9p9pler7xeugaau9s5h0plnqwchl5cgj2el03y5e0m65usqyyawjg9dar6t"`,
                 `"100"`,
                 `""`,
                 `""`,
@@ -83,19 +86,19 @@ import (
 
 func main() {
         url := "http://user:password@127.0.0.1:18891/wallet/foowallet"
-        loadWalletResult, err := elements.LoadWallet(url, []string{"foowallet", "true"})
+        loadWalletResult, err := elements.LoadWallet(url, []string{`"foowallet"`, "true"})
         if err != nil {
                 log.Fatal(err)
         }
         fmt.Printf("%+v\n", loadWalletResult)
 
         // wallet was created with passphrase "foobar"
-        err = elements.Walletpassphrase(url, []string{"foobar", "60"})
+        err = elements.Walletpassphrase(url, []string{`"foobar"`, "60"})
         if err != nil {
                 log.Fatal(err)
         }
 
-        unloadWalletResult, err := elements.UnloadWallet(url, []string{"foowallet", "true"})
+        unloadWalletResult, err := elements.UnloadWallet(url, []string{`"foowallet"`, "true"})
         if err != nil {
                 log.Fatal(err)
         }
@@ -146,7 +149,7 @@ func main() {
         }
 
         addressInfo, err := elements.GetAddressInfo(url, []string{
-                address,
+                `"` + address + `"`,
         })
         if err != nil {
                 log.Fatal(err)
@@ -161,7 +164,7 @@ func main() {
         }
 
         fundRawTransactionResult, err := elements.FundRawTransaction(url, []string{
-                hex,
+                `"` + hex + `"`,
                 `{"feeRate":0.00001000}`,
         })
         if err != nil {
@@ -196,7 +199,7 @@ func main() {
         }
 
         rawIssueAssetResults, err := elements.RawIssueAsset(url, []string{
-                fundRawTransactionResult.Hex,
+                `"` + fundRawTransactionResult.Hex + `"`,
                 `[{"asset_amount":0.00000001, "asset_address":"` + address + `", "blind":false, "contract_hash":"` + fmt.Sprintf("%+x", hash) + `"}]`,
         })
         if err != nil {
@@ -205,7 +208,7 @@ func main() {
 
         rawIssueAssetResult := rawIssueAssetResults[len(rawIssueAssetResults)-1]
         hex, err = elements.BlindRawTransaction(url, []string{
-                rawIssueAssetResult.Hex,
+                `"` + rawIssueAssetResult.Hex + `"`,
                 `true, [], false`,
         })
         if err != nil {
@@ -213,7 +216,7 @@ func main() {
         }
 
         signRawTransactionWithWalletResult, err := elements.SignRawTransactionWithWallet(url, []string{
-                hex,
+                `"` + hex + `"`,
         })
         if err != nil {
                 log.Fatal(err)
@@ -232,7 +235,7 @@ func main() {
         }
 
         hex, err = elements.SendRawTransaction(url, []string{
-                signRawTransactionWithWalletResult.Hex,
+                `"` + signRawTransactionWithWalletResult.Hex + `"`,
         })
         if err != nil {
                 log.Fatal(err)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/rddl-network/elements-rpc
 
 go 1.19
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.9.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/rpc.go
+++ b/rpc.go
@@ -25,21 +25,17 @@ func init() {
 	Client = &http.Client{}
 }
 
-func parse(params []string) (param string) {
+func Parse(params []string) (param string) {
 	if len(params) == 0 {
 		param = ""
 		return
-	}
-
-	if !strings.HasPrefix(params[0], "[") || !strings.HasSuffix(params[0], "]") {
-		params[0] = `"` + params[0] + `"`
 	}
 	param = strings.Join(params, ",")
 	return
 }
 
 func SendRequest(url, method string, params []string) (result []byte, err error) {
-	param := parse(params)
+	param := Parse(params)
 	jsonStr := fmt.Sprintf(`{"jsonrpc":"1.0","method":"%s","params":[%s]}`, method, param)
 
 	ctx := context.Background()

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -1,0 +1,46 @@
+package elementsrpc_test
+
+import (
+	"testing"
+
+	elementsrpc "github.com/rddl-network/elements-rpc"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		input          []string
+		expectedResult string
+	}{
+		{
+			[]string{"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d"},
+			"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+		},
+		{
+			[]string{"\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\""},
+			"\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"",
+		},
+		{
+			[]string{
+				"10",
+				"false",
+				"true",
+				"tex1qr4p5fwsttwsfqvk832gx2pqq44d9pdccwcfjtg",
+				"06c20c8de513527f1ae6c901f74a05126525ac2d7e89306f4a7fd5ec4e674403",
+			},
+			"10,false,true,tex1qr4p5fwsttwsfqvk832gx2pqq44d9pdccwcfjtg,06c20c8de513527f1ae6c901f74a05126525ac2d7e89306f4a7fd5ec4e674403",
+		},
+		{
+			[]string{`[]`, `[{"data":"00"}]`},
+			"[],[{\"data\":\"00\"}]",
+		},
+		{
+			[]string{`"abc"`, `[{"data":"00"}]`},
+			"\"abc\",[{\"data\":\"00\"}]",
+		},
+	} {
+		result := elementsrpc.Parse(tc.input)
+		assert.Equal(t, tc.expectedResult, result)
+	}
+}


### PR DESCRIPTION
* dedicated tests for the Parse method were added.
* made Parse more generic to take the first parameter as it is (this is a breaking change)